### PR TITLE
Switch to docker-asciidoctor image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: Action test
   
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ master ]
 
 jobs:
   test-html:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM ruby:2-alpine
+FROM asciidoctor/docker-asciidoctor:1.60@sha256:0c8df5a7688303b70fb8db3bec25c19503d7232d38b61cfaef0c943e1722c018
 
-RUN gem install asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
-
-RUN apk add --no-cache \
+RUN apk add \
       chromium \
       nss \
       freetype \


### PR DESCRIPTION
Use the official docker-asciidoctor image to save 5 minutes of built time on average.